### PR TITLE
Fix 'contains' check and add 'not_contains' check

### DIFF
--- a/retry_pytest/__init__.py
+++ b/retry_pytest/__init__.py
@@ -16,6 +16,6 @@
 
 
 __name__ = 'retry_pytest'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __author__ = 'Alexander Evdokimov'
 __author_email__ = '1812gg@bk.ru'

--- a/retry_pytest/command.py
+++ b/retry_pytest/command.py
@@ -144,6 +144,9 @@ class Command:
     def contains(self, data):
         self._condition = lambda: data in self.result
 
+    def not_contains(self, data):
+        self._condition = lambda: data not in self.result
+
     def __call__(self, *args, **kwargs):
         self._result_value = self._command(*self._args, **self._kwargs)
         return self._condition()

--- a/retry_pytest/command.py
+++ b/retry_pytest/command.py
@@ -142,7 +142,7 @@ class Command:
         return self
 
     def contains(self, data):
-        self._condition = data in self.result
+        self._condition = lambda: data in self.result
 
     def __call__(self, *args, **kwargs):
         self._result_value = self._command(*self._args, **self._kwargs)


### PR DESCRIPTION
Checked by
```
from retry_pytest.retry import Retry
with Retry(timeout=2) as r:
    r.check(list, [1, 2]).contains(2)

with Retry(timeout=2) as r:
    r.check(list, [1, 2]).contains(4)
Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "/Users/a.vasiliev/PycharmProjects/retry-pytest/retry_pytest/retry.py", line 86, in __exit__
    raise exc_val
AssertionError: Retry: timeout 2s exceeded

with Retry(timeout=2) as r:
    r.check(list, [1, 2]).not_contains(4)

with Retry(timeout=2) as r:
    r.check(list, [1, 2]).not_contains(2)
Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "/Users/a.vasiliev/PycharmProjects/retry-pytest/retry_pytest/retry.py", line 86, in __exit__
    raise exc_val
AssertionError: Retry: timeout 2s exceeded

```