### PR TITLE
Do first check immediately

### DIFF
--- a/retry_pytest/retry.py
+++ b/retry_pytest/retry.py
@@ -66,9 +66,9 @@ class Retry:
         try:
             for _ in range(ceil(self._timeout / self._poll_frequency)):
                 try:
-                    sleep(self._poll_frequency)
                     if all([f() for f in self._command_queue]):
                         break
+                    sleep(self._poll_frequency)
                 except self._exceptions as e:
                     if self._show_expected:
                         allure.attach(


### PR DESCRIPTION
SImple code
```py
with Retry(timeout=10, poll_frequency=2) as r:
    r.check(some_method).is_not(None)
```

Actual result:
First attemp to run `some_method` will be after 2 sec and next in 2 sec

Expected:
First attemp to run `some_method` will be immediately and next in 2 sec