### PR TITLE
fix: Handle poll_frequency with expected exception cases

### DIFF
--- a/retry_pytest/retry.py
+++ b/retry_pytest/retry.py
@@ -64,11 +64,12 @@ class Retry:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            for _ in range(ceil(self._timeout / self._poll_frequency)):
+            for i in range(ceil(self._timeout / self._poll_frequency)):
                 try:
+                    if i > 0:
+                        sleep(self._poll_frequency)
                     if all([f() for f in self._command_queue]):
                         break
-                    sleep(self._poll_frequency)
                 except self._exceptions as e:
                     if self._show_expected:
                         allure.attach(


### PR DESCRIPTION
Previous change added regression for cases with expected exception

Simple code:
```py
with Retry(MyException, title='Retry', timeout=10, poll_frequency=2) as r:
    r.check(some_method).is_not(False)
```

Actual result:
Retry doesn't honor poll_frequency value. Each attempt runs as fast as possible

Expected result:
Each attempt runs every 2 sec