### PR TITLE
feat: Log above exception

### DIFF
--- a/retry_pytest/retry.py
+++ b/retry_pytest/retry.py
@@ -98,6 +98,8 @@ class Retry:
             exc_tb=exc_tb
         )
         if exc_val:
+            if not self._above_exception:
+                raise exc_val
             try:
                 raise self._above_exception
             except Exception as e:


### PR DESCRIPTION
For easier debugging of exceptions inside Retry, it is suggested to log them when they occur.

Simple code:
```py
import operator
from retry_pytest.retry import Retry

with Retry(ZeroDivisionError, title='custom allure step title for skip ZeroDivisionError', timeout=10, poll_frequency=2) as r:
    r.check(operator.truediv, 4, 0).equal(2)
```

Log exception before:
```
Traceback (most recent call last):
  File "/home/username/retry-pytest/quick_check.py", line 4, in <module>
    with Retry(ZeroDivisionError, title='custom allure step title for skip ZeroDivisionError', timeout=10, poll_frequency=2) as r:
  File "/home/username/retry-pytest/retry_pytest/retry.py", line 99, in __exit__
    raise exc_val
AssertionError: custom allure step title for skip ZeroDivisionError: timeout 10s exceeded
```

Log exception after:
```
Traceback (most recent call last):
  File "/home/username/retry-pytest/retry_pytest/retry.py", line 102, in __exit__
    raise self._parent_e
  File "/home/username/retry-pytest/retry_pytest/retry.py", line 75, in __exit__
    if all([f() for f in self._command_queue]):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/username/retry-pytest/retry_pytest/retry.py", line 75, in <listcomp>
    if all([f() for f in self._command_queue]):
            ^^^
  File "/home/username/retry-pytest/retry_pytest/command.py", line 151, in __call__
    self._result_value = self._command(*self._args, **self._kwargs)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ZeroDivisionError: division by zero

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/username/retry-pytest/quick_check.py", line 4, in <module>
    with Retry(ZeroDivisionError, title='custom allure step title for skip ZeroDivisionError', timeout=10, poll_frequency=2) as r:
  File "/home/username/retry-pytest/retry_pytest/retry.py", line 104, in __exit__
    raise exc_val from e
AssertionError: custom allure step title for skip ZeroDivisionError: timeout 10s exceeded
```